### PR TITLE
feat(seeding): Add Bogus library and implement post/comment seeding

### DIFF
--- a/CookingBlogBackend/PostApiService.Tests/PostApiService.Tests.csproj
+++ b/CookingBlogBackend/PostApiService.Tests/PostApiService.Tests.csproj
@@ -17,7 +17,6 @@
 	</ItemGroup>	
 
 	<ItemGroup>
-		<PackageReference Include="Bogus" Version="35.6.1" />
 		<PackageReference Include="coverlet.collector" Version="6.0.3">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>

--- a/CookingBlogBackend/PostApiService/Infrastructure/ServiceRegistration.cs
+++ b/CookingBlogBackend/PostApiService/Infrastructure/ServiceRegistration.cs
@@ -204,67 +204,22 @@ namespace PostApiService.Infrastructure
                 var cntx = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                 await cntx.Database.EnsureDeletedAsync();
 
+
                 if (await cntx.Database.EnsureCreatedAsync())
                 {
-                    var posts = new List<Post>
-                    {
-                        new Post
-                        {
-                            Title = "First Post",
-                            Description = "Description for first post",
-                            Content = "This is the content of the first post.",
-                            Author = "Peter Jack",
-                            CreateAt = DateTime.Now,
-                            ImageUrl = "/images/placeholder.jpg",
-                            MetaTitle = "Meta title info",
-                            MetaDescription = "This is meta description",
-                            Slug = "first-post"
-                        },
-                        new Post
-                        {
-                            Title = "Second Post",
-                            Description = "Description for second post",
-                            Content = "This is the content of the second post.",
-                            Author = "Jay Way",
-                            CreateAt = DateTime.Now,
-                            ImageUrl = "/images/placeholder.jpg",
-                            MetaTitle = "Meta title info 2",
-                            MetaDescription = "This is meta description 2",
-                            Slug = "second-post"
-                        }
-                    };
+                    var postsList = SeedData.GetPostsWithComments(count: 150, commentCount: 20);
 
-                    await cntx.Posts.AddRangeAsync(posts);
-                    await cntx.SaveChangesAsync();
+                    await cntx.Posts.AddRangeAsync(postsList);
 
-                    var comments = new List<Comment>
+                    var allComments = postsList
+                        .SelectMany(p => p.Comments)
+                        .ToList();
+
+                    if (allComments.Any())
                     {
-                        new Comment
-                        {
-                            Author = "John Doe",
-                            Content = "Great post!",
-                            CreatedAt = DateTime.Now,
-                            PostId = posts[0].Id,
-                            UserId = "testUserId"
-                        },
-                        new Comment
-                        {
-                            Author = "Jane Doe",
-                            Content = "I totally agree with this!",
-                            CreatedAt = DateTime.Now,
-                            PostId = posts[0].Id,
-                            UserId = "testUserId"
-                        },
-                        new Comment
-                        {
-                            Author = "Alice",
-                            Content = "This is a comment on the second post.",
-                            CreatedAt = DateTime.Now,
-                            PostId = posts[1].Id,
-                            UserId = "testUserId"
-                        }
-                    };
-                    await cntx.Comments.AddRangeAsync(comments);
+                        await cntx.Comments.AddRangeAsync(allComments);
+                    }
+
                     await cntx.SaveChangesAsync();
                 }
             }

--- a/CookingBlogBackend/PostApiService/PostApiService.csproj
+++ b/CookingBlogBackend/PostApiService/PostApiService.csproj
@@ -7,6 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Bogus" Version="35.6.5" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />		
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />

--- a/CookingBlogBackend/PostApiService/SeedData.cs
+++ b/CookingBlogBackend/PostApiService/SeedData.cs
@@ -1,0 +1,76 @@
+﻿using Bogus;
+using PostApiService.Models;
+
+namespace PostApiService
+{
+    public static class SeedData
+    {
+        public static List<Post> GetPostsWithComments(int count = 10,
+            bool useNewSeed = false,
+            bool generateComments = true,
+            int commentCount = 1,
+            bool generateIds = false)
+        {
+            var posts = GetPostFaker(useNewSeed, generateComments, commentCount, generateIds).Generate(count);
+
+            if (generateIds)
+            {
+                int postId = 1;
+                int commentId = 1;
+
+                foreach (var post in posts)
+                {
+                    post.Id = postId++;
+
+                    if (post.Comments != null)
+                    {
+                        foreach (var comment in post.Comments)
+                        {
+                            comment.Id = commentId++;
+                            comment.PostId = post.Id;
+                        }
+                    }
+                }
+            }
+
+            return posts;
+        }
+
+        private static Faker<Post> GetPostFaker(bool useNewSeed,
+            bool generateComments,
+            int commentCount,
+            bool generateIds = false)
+        {
+            var seed = 0;
+            if (useNewSeed)
+            {
+                seed = Random.Shared.Next(10, int.MaxValue);
+            }
+
+            return new Faker<Post>()
+                .RuleFor(p => p.Id, _ => 0)
+                .RuleFor(p => p.Title, f => f.Lorem.Sentence(3))
+                .RuleFor(p => p.Description, f => f.Lorem.Paragraph(1))
+                .RuleFor(p => p.Content, f => f.Lorem.Paragraphs(3))
+                .RuleFor(p => p.Author, f => f.Person.FullName)
+                .RuleFor(p => p.ImageUrl, f => f.Image.PicsumUrl())
+                .RuleFor(p => p.MetaTitle, f => f.Lorem.Sentence(2))
+                .RuleFor(p => p.MetaDescription, f => f.Lorem.Sentence(8))
+                .RuleFor(p => p.Slug, f => f.Lorem.Slug())
+                .RuleFor(p => p.Comments, (f, post) =>
+                {
+                    if (!generateComments)
+                        return new List<Comment>();
+
+                    return new Faker<Comment>()
+                        .RuleFor(c => c.Id, _ => 0)
+                        .RuleFor(c => c.PostId, _ => post.Id)
+                        .RuleFor(c => c.Author, fc => fc.Person.FullName)
+                        .RuleFor(c => c.Content, fc => fc.Lorem.Sentence(3))
+                        .RuleFor(c => c.UserId, _ => "testUserId")
+                        .Generate(commentCount);
+                })
+                .UseSeed(seed);
+        }
+    }
+}


### PR DESCRIPTION
- Installed Bogus for generating fake data
- Added SeedData class to create Posts with optional Comments
- Implemented configurable faker rules for Posts and Comments
- Added ability to generate fixed IDs for deterministic seeding
- Integrated seeding pipeline into application startup via SeedDataAsync
- Database now auto-creates and populates with 150 posts and 20 comments each for testing pagination