### PR TITLE
refactor: introduce base services hierarchy and unify result handling

### DIFF
--- a/CookingBlogBackend/PostApiService.Tests/IntegrationTests/Services/CategoryServiceIntegrationTests.cs
+++ b/CookingBlogBackend/PostApiService.Tests/IntegrationTests/Services/CategoryServiceIntegrationTests.cs
@@ -22,7 +22,7 @@ namespace PostApiService.Tests.IntegrationTests.Services
             var categoriesToSeed = TestDataHelper.GetCulinaryCategories();
             _fixture.SeedCategoryAsync(context, categoriesToSeed).Wait();
 
-            var postRepo = new Repository<Post>(context);
+            var postRepo = new PostRepository(context);
             var repo = new Repository<Category>(context);
             var service = new CategoryService(repo, postRepo);
 

--- a/CookingBlogBackend/PostApiService.Tests/IntegrationTests/Services/PostServiceIntegrationTests.cs
+++ b/CookingBlogBackend/PostApiService.Tests/IntegrationTests/Services/PostServiceIntegrationTests.cs
@@ -31,7 +31,7 @@ namespace PostApiService.Tests.IntegrationTests.Services
 
         private TestSetup CreateTestSetup(ApplicationDbContext context, List<Post> posts, List<Category> categories)
         {
-            var repo = new Repository<Post>(context);
+            var repo = new PostRepository(context);
             var webContextMock = Substitute.For<IWebContext>();
             var sanitizeServiceMock = Substitute.For<IHtmlSanitizationService>();
             var catService = new CategoryService(new Repository<Category>(context), repo);

--- a/CookingBlogBackend/PostApiService.Tests/UnitTests/Services/AuthServiceTests.cs
+++ b/CookingBlogBackend/PostApiService.Tests/UnitTests/Services/AuthServiceTests.cs
@@ -134,8 +134,8 @@ namespace PostApiService.Tests.UnitTests.Services
             // Assert
             Assert.Equal(ResultStatus.Invalid, result.Status);
 
-            Assert.Contains("Password is too short.", result.Message);
-            Assert.Contains("Password must have at least one digit.", result.Message);
+            Assert.Equal(Auth.Registration.Errors.DefaultRegistrationError, result.Message);
+            Assert.Equal(Auth.Registration.Errors.DefaultRegistrationErrorCode, result.ErrorCode);
 
             await _mockAuthRepository.DidNotReceive().AddClaimAsync(
                 Arg.Any<IdentityUser>(), Arg.Any<Claim>(), Arg.Any<CancellationToken>());
@@ -187,6 +187,7 @@ namespace PostApiService.Tests.UnitTests.Services
             // Assert
             Assert.False(result.IsSuccess);
             Assert.Equal(Auth.LoginM.Errors.InvalidCredentials, result.Message);
+            Assert.Equal(Auth.LoginM.Errors.InvalidCredentialsErrorCode, result.ErrorCode);
 
             await _mockAuthRepository.DidNotReceiveWithAnyArgs().CheckPasswordAsync(default!, default!);
         }
@@ -210,6 +211,7 @@ namespace PostApiService.Tests.UnitTests.Services
             // Assert
             Assert.False(result.IsSuccess);
             Assert.Equal(Auth.LoginM.Errors.InvalidCredentials, result.Message);
+            Assert.Equal(Auth.LoginM.Errors.InvalidCredentialsErrorCode, result.ErrorCode);
 
             await _mockAuthRepository.Received(1).FindByNameAsync(loginDto.UserName, Arg.Any<CancellationToken>());
             await _mockAuthRepository.Received(1).CheckPasswordAsync(identityUser, loginDto.Password, Arg.Any<CancellationToken>());

--- a/CookingBlogBackend/PostApiService.Tests/UnitTests/Services/CategoryServiceTests.cs
+++ b/CookingBlogBackend/PostApiService.Tests/UnitTests/Services/CategoryServiceTests.cs
@@ -9,12 +9,12 @@ namespace PostApiService.Tests.UnitTests.Services
     public class CategoryServiceTests
     {
         private readonly IRepository<Category> _mockCategoryRepo;
-        private readonly IRepository<Post> _mockPostRepo;
+        private readonly IPostRepository _mockPostRepo;
         private readonly CategoryService _categoryService;
 
         public CategoryServiceTests()
         {
-            _mockPostRepo = Substitute.For<IRepository<Post>>();
+            _mockPostRepo = Substitute.For<IPostRepository>();
             _mockCategoryRepo = Substitute.For<IRepository<Category>>();
             _categoryService = new CategoryService(_mockCategoryRepo, _mockPostRepo);
         }

--- a/CookingBlogBackend/PostApiService.Tests/UnitTests/Services/PostServiceTests.cs
+++ b/CookingBlogBackend/PostApiService.Tests/UnitTests/Services/PostServiceTests.cs
@@ -11,7 +11,7 @@ namespace PostApiService.Tests.UnitTests
 {
     public class PostServiceTests
     {
-        private readonly IRepository<Post> _mockRepository;
+        private readonly IPostRepository _mockRepository;
         private readonly IWebContext _mockWebContext;
         private readonly IHtmlSanitizationService _mockSanitizationService;
         private readonly ICategoryService _mockCategoryService;
@@ -20,7 +20,7 @@ namespace PostApiService.Tests.UnitTests
 
         public PostServiceTests()
         {
-            _mockRepository = Substitute.For<IRepository<Post>>();
+            _mockRepository = Substitute.For<IPostRepository>();
             _mockWebContext = Substitute.For<IWebContext>();
             _mockSanitizationService = Substitute.For<IHtmlSanitizationService>();
             _mockCategoryService = Substitute.For<ICategoryService>();

--- a/CookingBlogBackend/PostApiService/Infrastructure/Constants/Messages.cs
+++ b/CookingBlogBackend/PostApiService/Infrastructure/Constants/Messages.cs
@@ -32,8 +32,11 @@
             public static class Errors
             {
                 public const string CategoryNotFound = "Category was not found.";
+                public const string CategoryNotFoundCode = "CATEGORY_NOT_FOUND";
                 public const string CategoryAlreadyExists = "Category with Name '{0}' already exists.";
+                public const string CategoryAlreadyExistsCode = "CATEGORY_ALREADY_EXISTS";
                 public const string CannotDeleteCategoryWithPosts = "Cannot delete category with posts";
+                public const string CannotDeleteCategoryWithPostsCode = "CATEGORY_DELETE_BLOCKED";
             }
 
             public static class Success
@@ -71,6 +74,7 @@
                 public static class Errors
                 {
                     public const string InvalidCredentials = "Invalid username or password. Please check your credentials and try again.";
+                    public const string InvalidCredentialsErrorCode = "INVALID_CREDENTIALS";
                     public const string UnauthorizedAccess = "Unauthorized Access";
                     public const string UnauthorizedAccessCode = "UNAUTHORIZED";                    
                 }
@@ -87,6 +91,8 @@
                 {
                     public const string InvalidRegistrationData = "Invalid registration data. Please check the provided information.";
                     public const string InvalidRegistrationDataCode = "REG_INVALID_DATA";
+                    public const string DefaultRegistrationError = "An error occurred during registration. Please check your data or try again later.";                   
+                    public const string DefaultRegistrationErrorCode = "REGISTRATION_FAILED";
                     public const string UserAlreadyExists = "Username or email is already taken.";
                     public const string UserAlreadyExistsCode = "REG_USER_ALREADY_EXISTS";                   
                     public const string ClaimAssignmentFailed = "Failed to assign claim to user.";

--- a/CookingBlogBackend/PostApiService/Services/BaseResultService.cs
+++ b/CookingBlogBackend/PostApiService/Services/BaseResultService.cs
@@ -1,0 +1,38 @@
+﻿namespace PostApiService.Services
+{
+    public abstract class BaseResultService
+    {
+        protected Result NotFound(string message, string? code = null) => Result.NotFound(message, code);
+
+        protected Result<T> NotFound<T>(string message, string code) => Result<T>.NotFound(message, code);
+
+        protected Result Unauthorized()
+        {
+            return Result.Unauthorized(Auth.LoginM.Errors.UnauthorizedAccess,
+                Auth.LoginM.Errors.UnauthorizedAccessCode);
+        }
+
+        protected Result<T> Unauthorized<T>(string? message = null, string? errorCode = null)
+        {
+            return Result<T>.Unauthorized(
+                message ?? Auth.LoginM.Errors.UnauthorizedAccess,
+                errorCode ?? Auth.LoginM.Errors.UnauthorizedAccessCode);
+        }
+
+        protected Result Forbidden(string message, string code) => Result.Forbidden(message, code);
+
+        protected Result<T> Forbidden<T>(string message, string code) => Result<T>.Forbidden(message, code);
+
+        protected Result<T> Invalid<T>(string message, string code) => Result<T>.Invalid(message, code);
+
+        protected Result Conflict(string message, string code) => Result.Conflict(message, code);
+
+        protected Result<T> Conflict<T>(string message, string code) => Result<T>.Conflict(message, code);
+
+        protected Result<T> Error<T>(string message, string errorCode) => Result<T>.Error(message, errorCode);
+
+        protected Result Success(string message) => Result.Success(message);
+
+        protected Result<T> Success<T>(T data, string? message = null) => Result<T>.Success(data, message);
+    }
+}

--- a/CookingBlogBackend/PostApiService/Services/BaseService.cs
+++ b/CookingBlogBackend/PostApiService/Services/BaseService.cs
@@ -1,0 +1,12 @@
+﻿using PostApiService.Infrastructure.Services;
+
+namespace PostApiService.Services
+{
+    public abstract class BaseService: BaseResultService
+    {
+        protected readonly IWebContext WebContext;
+
+        protected BaseService(IWebContext webContext) => WebContext = webContext;        
+    }
+}
+


### PR DESCRIPTION
- Add BaseResultService to handle standardize Result responses.
- Add BaseService inheriting from BaseResultService to provide WebContext.
- Refactor Auth, Post, Category, and Comment services to use the new hierarchy.
- Update unit and integration tests to align with service constructor changes.
- Standardize error codes and success messages across all services.