### PR TITLE
feat: add category slugs, transliteration and html stripping

### DIFF
--- a/CookingBlogBackend/PostApiService.Tests/Fixtures/BaseTestFixture.cs
+++ b/CookingBlogBackend/PostApiService.Tests/Fixtures/BaseTestFixture.cs
@@ -48,7 +48,9 @@ namespace PostApiService.Tests.Fixtures
         {
             using var scope = Services!.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            await context.Database.EnsureCreatedAsync();
+
+            await context.Database.MigrateAsync();
+            await context.Database.EnsureCreatedAsync();           
         }
 
         private async Task InitializeRespawnerAsync()

--- a/CookingBlogBackend/PostApiService.Tests/Helper/TestDataHelper.cs
+++ b/CookingBlogBackend/PostApiService.Tests/Helper/TestDataHelper.cs
@@ -185,7 +185,7 @@ namespace PostApiService.Tests.Helper
 
         public static List<CategoryDto> GetCategoryListDtos(ICollection<Category> categories)
         {
-            return categories.Select(c => new CategoryDto(c.Id, c.Name)).ToList();
+            return categories.Select(c => new CategoryDto(c.Id, c.Name, c.Slug)).ToList();
         }
 
         public static PostCreateDto ToPostCreateDto(Post post)
@@ -606,12 +606,12 @@ namespace PostApiService.Tests.Helper
         {
             return new List<Category>
             {
-                new Category { Name = "Breakfast" },
-                new Category { Name = "Main Course" },
-                new Category { Name = "Desserts" },
-                new Category { Name = "Healthy Food" },
-                new Category { Name = "Beverages" },
-                new Category { Name = "Vegetarian" }
+                new Category { Name = "Breakfast", Slug = StringHelper.GenerateSlug("Breakfast") },
+                new Category { Name = "Main Course", Slug = StringHelper.GenerateSlug("Main Course") },
+                new Category { Name = "Desserts", Slug = StringHelper.GenerateSlug("Desserts") },
+                new Category { Name = "Healthy Food", Slug = StringHelper.GenerateSlug("Healthy Food") },
+                new Category { Name = "Beverages", Slug = StringHelper.GenerateSlug("Beverages") },
+                new Category { Name = "Vegetarian", Slug = StringHelper.GenerateSlug("Vegetarian") }
             };
         }
 

--- a/CookingBlogBackend/PostApiService.Tests/Infrastructure/SharedDbContainer.cs
+++ b/CookingBlogBackend/PostApiService.Tests/Infrastructure/SharedDbContainer.cs
@@ -5,8 +5,9 @@ namespace PostApiService.Tests.Infrastructure
     public static class SharedDbContainer
     {
         private static readonly MsSqlContainer _container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest")
-            .WithReuse(true).Build();
-        
+            .WithReuse(true)
+            .Build();
+
         private static readonly Lazy<Task> _initializer = new(() => _container.StartAsync());
 
         public static string ConnectionString => _container.GetConnectionString();

--- a/CookingBlogBackend/PostApiService.Tests/UnitTests/Controllers/CategoryControllerTests.cs
+++ b/CookingBlogBackend/PostApiService.Tests/UnitTests/Controllers/CategoryControllerTests.cs
@@ -23,7 +23,7 @@ namespace PostApiService.Tests.UnitTests.Controllers
         {
             // Arrange
             var token = new CancellationToken(false);
-            var categoriesFromService = new List<CategoryDto> { new CategoryDto(1, "Test") };
+            var categoriesFromService = new List<CategoryDto> { new CategoryDto(1, "Test", "test-slug") };
             var expectedResult = Result<List<CategoryDto>>.Success(categoriesFromService);
 
             _mockCategoryService.GetAllCategoriesAsync(token)
@@ -47,7 +47,7 @@ namespace PostApiService.Tests.UnitTests.Controllers
             // Arrange
             var token = new CancellationToken(false);
             const int CategoryId = 3;
-            var categoryFromService = new CategoryDto(1, "Test");
+            var categoryFromService = new CategoryDto(1, "Test", "test-slug");
             var expectedResult = Result<CategoryDto>.Success(categoryFromService);
 
             _mockCategoryService.GetCategoryByIdAsync(CategoryId, token)
@@ -92,8 +92,8 @@ namespace PostApiService.Tests.UnitTests.Controllers
         {
             // Arrange
             var token = new CancellationToken(false);
-            var createDto = new CreateCategoryDto { Name = "New Category" };
-            var responseDto = new CategoryDto(1, createDto.Name);
+            var createDto = new CreateCategoryDto { Name = "New Category", Slug = "new-category-slug" };
+            var responseDto = new CategoryDto(1, createDto.Name, createDto.Slug);
             var expectedResult = Result<CategoryDto>.Success(responseDto);
 
             _mockCategoryService.AddCategoryAsync(createDto, token)
@@ -118,7 +118,7 @@ namespace PostApiService.Tests.UnitTests.Controllers
         {
             // Arrange
             var createDto = new CreateCategoryDto { Name = "Existing Category" };
-            var errorMessage = string.Format(CategoryM.Errors.CategoryAlreadyExists, createDto.Name);
+            var errorMessage = string.Format(CategoryM.Errors.CategoryOrSlugExists, createDto.Name, createDto.Slug);
 
             var expectedResult = Result<CategoryDto>.Conflict(errorMessage);
 
@@ -144,7 +144,7 @@ namespace PostApiService.Tests.UnitTests.Controllers
             var token = new CancellationToken(false);
             const int categoryId = 1;
             var updateDto = new UpdateCategoryDto { Name = "Updated Name" };
-            var responseDto = new CategoryDto(categoryId, "Updated Name");
+            var responseDto = new CategoryDto(categoryId, "Updated Name", "test-slug");
             var expectedResult = Result<CategoryDto>.Success(responseDto);
 
             _mockCategoryService.UpdateCategoryAsync(categoryId, updateDto, token)
@@ -190,7 +190,7 @@ namespace PostApiService.Tests.UnitTests.Controllers
             // Arrange
             const int categoryId = 1;
             var updateDto = new UpdateCategoryDto { Name = "Existing Category" };
-            var errorMessage = string.Format(CategoryM.Errors.CategoryAlreadyExists, updateDto.Name);
+            var errorMessage = string.Format(CategoryM.Errors.CategoryOrSlugExists, updateDto.Name, updateDto.Slug);
             var expectedResult = Result<CategoryDto>.Conflict(errorMessage);
 
             _mockCategoryService.UpdateCategoryAsync(categoryId, updateDto, Arg.Any<CancellationToken>())

--- a/CookingBlogBackend/PostApiService/Helper/CategoryMappingExtensions.cs
+++ b/CookingBlogBackend/PostApiService/Helper/CategoryMappingExtensions.cs
@@ -6,13 +6,14 @@ namespace PostApiService.Helper
     public static class CategoryMappingExtensions
     {
         public static CategoryDto ToDto(this Category category) =>
-        new(category.Id, category.Name);
+        new(category.Id, category.Name, category.Slug);
 
         public static Category ToEntity(this CreateCategoryDto dto) =>
-            new() { Name = dto.Name };       
+            new() { Name = dto.Name, Slug = dto.Slug! };       
         public static void UpdateEntity(this UpdateCategoryDto dto, Category existingCategory)
         {
             existingCategory.Name = dto.Name;
+            existingCategory.Slug = dto.Slug!;
         }
     }
 }

--- a/CookingBlogBackend/PostApiService/Helper/StringHelper.cs
+++ b/CookingBlogBackend/PostApiService/Helper/StringHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using AnyAscii;
+using System.Text.RegularExpressions;
 
 namespace PostApiService.Helper
 {
@@ -16,6 +17,21 @@ namespace PostApiService.Helper
                 return input;
 
             return Regex.Replace(input, "<.*?>", string.Empty).Trim();
+        }
+
+        public static string GenerateSlug(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return string.Empty;
+           
+            string slug = name.Transliterate();
+            
+            slug = slug.ToLowerInvariant();           
+            slug = Regex.Replace(slug, @"[^a-z0-9\s-]", "");
+            slug = Regex.Replace(slug, @"[\s_]+", "-");
+            slug = Regex.Replace(slug, @"-+", "-").Trim('-');
+
+            return slug;
         }
     }
 }

--- a/CookingBlogBackend/PostApiService/Infrastructure/Constants/Messages.cs
+++ b/CookingBlogBackend/PostApiService/Infrastructure/Constants/Messages.cs
@@ -33,8 +33,8 @@
             {
                 public const string CategoryNotFound = "Category was not found.";
                 public const string CategoryNotFoundCode = "CATEGORY_NOT_FOUND";
-                public const string CategoryAlreadyExists = "Category with Name '{0}' already exists.";
-                public const string CategoryAlreadyExistsCode = "CATEGORY_ALREADY_EXISTS";
+                public const string CategoryOrSlugExists = "Category with name '{0}' or slug '{1}' already exists.";
+                public const string CategoryOrSlugExistsCode = "CATEGORY_OR_SLUG_EXISTS";
                 public const string CannotDeleteCategoryWithPosts = "Cannot delete category with posts";
                 public const string CannotDeleteCategoryWithPostsCode = "CATEGORY_DELETE_BLOCKED";
             }

--- a/CookingBlogBackend/PostApiService/Migrations/20260128220008_Initial.Designer.cs
+++ b/CookingBlogBackend/PostApiService/Migrations/20260128220008_Initial.Designer.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace PostApiService.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20260117170306_Initial")]
+    [Migration("20260128220008_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -234,6 +234,11 @@ namespace PostApiService.Migrations
                         .IsRequired()
                         .HasMaxLength(20)
                         .HasColumnType("nvarchar(20)");
+
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
 
                     b.HasKey("Id");
 

--- a/CookingBlogBackend/PostApiService/Migrations/20260128220008_Initial.cs
+++ b/CookingBlogBackend/PostApiService/Migrations/20260128220008_Initial.cs
@@ -56,7 +56,8 @@ namespace PostApiService.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    Name = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false)
+                    Name = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
+                    Slug = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false)
                 },
                 constraints: table =>
                 {

--- a/CookingBlogBackend/PostApiService/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/CookingBlogBackend/PostApiService/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -232,6 +232,11 @@ namespace PostApiService.Migrations
                         .HasMaxLength(20)
                         .HasColumnType("nvarchar(20)");
 
+                    b.Property<string>("Slug")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("nvarchar(50)");
+
                     b.HasKey("Id");
 
                     b.HasIndex("Name")

--- a/CookingBlogBackend/PostApiService/Models/Category.cs
+++ b/CookingBlogBackend/PostApiService/Models/Category.cs
@@ -10,6 +10,10 @@ namespace PostApiService.Models
         [MaxLength(20)]
         public string Name { get; set; } = default!;
 
+        [MaxLength(50)]
+        [RegularExpression(@"^[a-z0-9-]+$")]
+        public string Slug { get; set; } = default!;
+
         public virtual ICollection<Post> Posts { get; set; } = new List<Post>();
     }
 }

--- a/CookingBlogBackend/PostApiService/Models/Dto/Requests/CreateCategoryDto.cs
+++ b/CookingBlogBackend/PostApiService/Models/Dto/Requests/CreateCategoryDto.cs
@@ -7,5 +7,9 @@ namespace PostApiService.Models.Dto.Requests
         [Required(ErrorMessage = Global.Validation.Required)]
         [StringLength(20, MinimumLength = 3, ErrorMessage = Global.Validation.LengthRange)]
         public string Name { get; set; } = default!;
+        
+        [StringLength(50, ErrorMessage = Global.Validation.LengthRange)]
+        [RegularExpression(@"^[a-z0-9-]+$", ErrorMessage = Global.Validation.SlugFormat)]
+        public string? Slug { get; set; }
     }
 }

--- a/CookingBlogBackend/PostApiService/Models/Dto/Requests/UpdateCategoryDto.cs
+++ b/CookingBlogBackend/PostApiService/Models/Dto/Requests/UpdateCategoryDto.cs
@@ -7,5 +7,9 @@ namespace PostApiService.Models.Dto.Requests
         [Required(ErrorMessage = Global.Validation.Required)]
         [StringLength(20, MinimumLength = 3, ErrorMessage = Global.Validation.LengthRange)]
         public string Name { get; set; } = default!;
+
+        [StringLength(50, ErrorMessage = Global.Validation.LengthRange)]
+        [RegularExpression(@"^[a-z0-9-]+$", ErrorMessage = Global.Validation.SlugFormat)]
+        public string? Slug { get; set; }
     }
 }

--- a/CookingBlogBackend/PostApiService/Models/Dto/Response/CategoryDto.cs
+++ b/CookingBlogBackend/PostApiService/Models/Dto/Response/CategoryDto.cs
@@ -1,9 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace PostApiService.Models.Dto.Response
+﻿namespace PostApiService.Models.Dto.Response
 {
     public record CategoryDto(
-        int Id,        
-        string Name
+        int Id,
+        string Name,
+        string Slug
     );
 }

--- a/CookingBlogBackend/PostApiService/PostApiService.csproj
+++ b/CookingBlogBackend/PostApiService/PostApiService.csproj
@@ -9,6 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AnyAscii" Version="0.3.3" />
 		<PackageReference Include="HtmlSanitizer" Version="9.0.889" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />		

--- a/CookingBlogBackend/PostApiService/SeedData.cs
+++ b/CookingBlogBackend/PostApiService/SeedData.cs
@@ -1,4 +1,5 @@
 ﻿using Bogus;
+using PostApiService.Helper;
 
 namespace PostApiService
 {
@@ -44,12 +45,12 @@ namespace PostApiService
         {
             var culinaryCategories = new[]
             {
-                new Category { Name = "Breakfast" },
-                new Category { Name = "Main Course" },
-                new Category { Name = "Desserts" },
-                new Category { Name = "Healthy Food" },
-                new Category { Name = "Beverages" },
-                new Category { Name = "Vegetarian" }
+                new Category { Name = "Breakfast", Slug = StringHelper.GenerateSlug("Breakfast") },
+                new Category { Name = "Main Course", Slug = StringHelper.GenerateSlug("Main Course") },
+                new Category { Name = "Desserts", Slug = StringHelper.GenerateSlug("Desserts") },
+                new Category { Name = "Healthy Food", Slug = StringHelper.GenerateSlug("Healthy Food") },
+                new Category { Name = "Beverages", Slug = StringHelper.GenerateSlug("Beverages") },
+                new Category { Name = "Vegetarian", Slug = StringHelper.GenerateSlug("Vegetarian") }
             };
 
             var seed = 0;

--- a/CookingBlogBackend/PostApiService/Services/CategoryService.cs
+++ b/CookingBlogBackend/PostApiService/Services/CategoryService.cs
@@ -1,4 +1,5 @@
-﻿using PostApiService.Helper;
+﻿using Microsoft.IdentityModel.Logging;
+using PostApiService.Helper;
 using PostApiService.Interfaces;
 using PostApiService.Models.Dto.Requests;
 using PostApiService.Models.Dto.Response;
@@ -50,33 +51,36 @@ namespace PostApiService.Services
         public async Task<Result<CategoryDto>> AddCategoryAsync
             (CreateCategoryDto categoryDto, CancellationToken ct = default)
         {
+            categoryDto.Name = categoryDto.Name.StripHtml();
+
+            string source = string.IsNullOrWhiteSpace(categoryDto.Slug) ? categoryDto.Name : categoryDto.Slug;
+            string finalSlug = StringHelper.GenerateSlug(source);
+
             var alreadyExists = await _categoryRepository
-                .AnyAsync(c => c.Name == categoryDto.Name, ct);
+                .AnyAsync(c => c.Name == categoryDto.Name || c.Slug == finalSlug, ct);
 
             if (alreadyExists)
             {
                 Log.Information(Categories.CategoryExists, categoryDto.Name);
-
-                return Conflict<CategoryDto>
-                    (string.Format(CategoryM.Errors.CategoryAlreadyExists, categoryDto.Name),
-                    CategoryM.Errors.CategoryAlreadyExistsCode);
+                return Conflict<CategoryDto>(
+                    string.Format(CategoryM.Errors.CategoryOrSlugExists, categoryDto.Name, finalSlug),
+                    CategoryM.Errors.CategoryOrSlugExistsCode);
             }
 
             var categoryEntity = CategoryMappingExtensions.ToEntity(categoryDto);
+            categoryEntity.Slug = finalSlug;            
 
             await _categoryRepository.AddAsync(categoryEntity, ct);
             await _categoryRepository.SaveChangesAsync(ct);
 
-            var responseDto = categoryEntity.ToDto();
-
-            return Success(responseDto, CategoryM.Success.CategoryAddedSuccessfully);
+            return Success(categoryEntity.ToDto(), CategoryM.Success.CategoryAddedSuccessfully);
         }
 
         public async Task<Result<CategoryDto>> UpdateCategoryAsync
             (int categoryId, UpdateCategoryDto categoryDto, CancellationToken ct = default)
         {
             var category = await _categoryRepository
-                .GetByIdAsync(categoryId, ct);
+                .GetByIdAsync(categoryId, ct);           
 
             if (category == null)
             {
@@ -86,21 +90,25 @@ namespace PostApiService.Services
                     CategoryM.Errors.CategoryNotFoundCode);
             }
 
-            var alreadyExists = await _categoryRepository
-                .AnyAsync(c => c.Name == categoryDto.Name && c.Id != categoryId, ct);
+            categoryDto.Name = categoryDto.Name.StripHtml();
+
+            string source = string.IsNullOrWhiteSpace(categoryDto.Slug) ? categoryDto.Name : categoryDto.Slug;
+            string finalSlug = StringHelper.GenerateSlug(source);
+
+            var alreadyExists = await _categoryRepository.AnyAsync(c =>
+                (c.Name == categoryDto.Name || c.Slug == finalSlug) && c.Id != categoryId, ct);            
 
             if (alreadyExists)
             {
                 Log.Information(Categories.CategoryExists, categoryDto.Name);
 
                 return Conflict<CategoryDto>
-                    (string.Format(CategoryM.Errors.CategoryAlreadyExists, categoryDto.Name),
-                    CategoryM.Errors.CategoryAlreadyExistsCode);
+                    (string.Format(CategoryM.Errors.CategoryOrSlugExists, categoryDto.Name, finalSlug),
+                    CategoryM.Errors.CategoryOrSlugExistsCode);
             }
 
-            categoryDto.UpdateEntity(category);
-
-            await _categoryRepository.UpdateAsync(category, ct);
+            categoryDto.Slug = finalSlug;
+            categoryDto.UpdateEntity(category);            
             await _categoryRepository.SaveChangesAsync(ct);
 
             var responseDto = category.ToDto();


### PR DESCRIPTION
- Slugs: Added Slug property to Category entity with automatic generation logic.
- Transliteration: Integrate AnyAscii library to convert category names into SEO-friendly Latin slugs.
- Security: Implement StripHtml to sanitize category names from HTML tags during creation and updates.
- Validation: Add conflict detection to prevent duplicate names and slugs in the database.
- Unit Tests: Add coverage for HTML stripping, slug generation logic, and unique constraint validation.