### PR TITLE
chore: implement robust Serilog configuration and environment-based logging

### DIFF
--- a/CookingBlogBackend/PostApiService/Infrastructure/ServiceRegistration.cs
+++ b/CookingBlogBackend/PostApiService/Infrastructure/ServiceRegistration.cs
@@ -9,6 +9,8 @@ using PostApiService.Interfaces;
 using PostApiService.Models.TypeSafe;
 using PostApiService.Repositories;
 using PostApiService.Services;
+using Serilog.Exceptions;
+using Serilog.Settings.Configuration;
 using System.Security.Claims;
 using System.Text;
 
@@ -18,15 +20,15 @@ namespace PostApiService.Infrastructure
     {
         /// <summary>
         /// Configures Serilog for file and console logging.
-        /// </summary>
-        public static void AddAppLogging(this IHostBuilder host)
+        /// </summary>        
+        public static void AddAppLogging(this IHostBuilder host, IConfiguration configuration)
         {
-            Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Information()
-                .WriteTo.Console()
-                .WriteTo.File("logs/api_validation_.txt",
-                    rollingInterval: RollingInterval.Day,
-                    retainedFileCountLimit: 7)
+            Log.Logger = new LoggerConfiguration()               
+                .ReadFrom.Configuration(configuration)
+                .Enrich.FromLogContext()
+                .Enrich.WithExceptionDetails()
+                .Enrich.WithThreadId()
+                .Enrich.WithMachineName()
                 .CreateLogger();
 
             host.UseSerilog();

--- a/CookingBlogBackend/PostApiService/PostApiService.csproj
+++ b/CookingBlogBackend/PostApiService/PostApiService.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="AnyAscii" Version="0.3.3" />
 		<PackageReference Include="HtmlSanitizer" Version="9.0.889" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />		
+		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />						
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
 	</ItemGroup>
 
@@ -31,7 +31,11 @@
 		<PackageReference Include="Serilog" Version="4.3.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+		<PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
+		<PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/CookingBlogBackend/PostApiService/Properties/launchSettings.json
+++ b/CookingBlogBackend/PostApiService/Properties/launchSettings.json
@@ -20,6 +20,16 @@
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7030;http://localhost:5189"
     },
+    "Production-Test": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Production"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:7030;http://localhost:5189"
+    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,

--- a/CookingBlogBackend/PostApiService/appsettings.Development.json
+++ b/CookingBlogBackend/PostApiService/appsettings.Development.json
@@ -1,10 +1,32 @@
 {
-  "ConnectionStrings": {
-    "DefaultConnection": "Server=MAX\\SQLEXPRESS;Database=PostApiDb;Trusted_Connection=True;MultipleActiveResultSets=True;TrustServerCertificate=True;"
-  },
-  "JwtConfiguration": {   
+  "JwtConfiguration": {
     "Issuer": "https://localhost:7030",
     "Audience": "https://localhost:4200",
     "TokenExpirationMinutes": 15
+  },
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Microsoft.AspNetCore": "Warning",
+        "Microsoft.AspNetCore.Mvc.Infrastructure": "Information",
+        "Microsoft.AspNetCore.Cors": "Information",
+        "Microsoft.EntityFrameworkCore": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Error",
+        "System": "Warning"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext", "WithThreadId", "WithMachineName" ]
   }
 }

--- a/CookingBlogBackend/PostApiService/appsettings.json
+++ b/CookingBlogBackend/PostApiService/appsettings.json
@@ -16,8 +16,10 @@
       "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information",
         "Microsoft.AspNetCore": "Warning",
         "Microsoft.EntityFrameworkCore": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Error",
         "System": "Warning"
       }
     },


### PR DESCRIPTION
- Move hardcoded logger setup to `appsettings.json` using `ReadFrom.Configuration`.
- Configure hierarchical logging:
    * `appsettings.json`: Minimalist production-ready setup (File/Console) with focus on critical info.
    * `appsettings.development.json`: Verbose logging (Infrastructure, CORS) with ANSI themes for local debugging.
- Enhance Production testing:
    * Add `Production-Test` profile to `launchSettings.json`.
    * Force `UserSecrets` loading in Production environment for local testing.
- Add log enrichment: ThreadId, MachineName, and ExceptionDetails.
- Fine-tune log overrides for Microsoft and EF Core to reduce noise.