### PR TITLE
fix: update HtmlSanitizer to v9.0.892 to patch security vulnerability

### DIFF
--- a/CookingBlogBackend/PostApiService/PostApiService.csproj
+++ b/CookingBlogBackend/PostApiService/PostApiService.csproj
@@ -10,7 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AnyAscii" Version="0.3.3" />
-		<PackageReference Include="HtmlSanitizer" Version="9.0.889" />
+		<PackageReference Include="HtmlSanitizer" Version="9.0.892" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
 		<PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.10" />						
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />


### PR DESCRIPTION
Updated the HtmlSanitizer package to version 9.0.892 to address a reported security vulnerability.

Changes:
- Bumped HtmlSanitizer version in PostApiServi project.
- Verified basic functionality locally to ensure no breaking changes.