### PR TITLE
feat(auth): add forbidden handling and constants

### DIFF
--- a/CookingBlogBackend/PostApiService/Infrastructure/Constants/Messages.cs
+++ b/CookingBlogBackend/PostApiService/Infrastructure/Constants/Messages.cs
@@ -80,8 +80,21 @@
                 {
                     public const string InvalidCredentials = "Invalid username or password. Please check your credentials and try again.";
                     public const string InvalidCredentialsErrorCode = "INVALID_CREDENTIALS";
+                    
                     public const string UnauthorizedAccess = "Unauthorized Access";
-                    public const string UnauthorizedAccessCode = "UNAUTHORIZED";                    
+                    public const string UnauthorizedAccessCode = "UNAUTHORIZED";
+
+                    public const string TokenMissing = "Authorization token is missing.";
+                    public const string TokenMissingErrorCode = "AUTH_REQUIRED";
+
+                    public const string SessionExpired = "Your session has expired. Please log in again.";
+                    public const string SessionExpiredErrorCode = "SESSION_EXPIRED";
+
+                    public const string InvalidToken = "The provided token is invalid.";
+                    public const string InvalidTokenErrorCode = "INVALID_TOKEN";
+
+                    public const string AccessForbidden = "Access denied. You do not have the required permissions.";
+                    public const string AccessForbiddenErrorCode = "FORBIDDEN";
                 }
 
                 public static class Success

--- a/CookingBlogBackend/PostApiService/Infrastructure/ServiceRegistration.cs
+++ b/CookingBlogBackend/PostApiService/Infrastructure/ServiceRegistration.cs
@@ -227,21 +227,33 @@ namespace PostApiService.Infrastructure
 
                             if (!hasToken)
                             {
-                                errorCode = "AUTH_REQUIRED";
-                                message = "Authorization token is missing.";
+                                errorCode = Auth.LoginM.Errors.TokenMissingErrorCode;
+                                message = Auth.LoginM.Errors.TokenMissing;
                             }
                             else if (isExpired)
                             {
-                                errorCode = "SESSION_EXPIRED";
-                                message = "Your session has expired. Please log in again.";
+                                errorCode = Auth.LoginM.Errors.SessionExpiredErrorCode;
+                                message = Auth.LoginM.Errors.SessionExpired;
                             }
                             else
                             {
-                                errorCode = "INVALID_TOKEN";
-                                message = "The provided token is invalid.";
+                                errorCode = Auth.LoginM.Errors.InvalidTokenErrorCode;
+                                message = Auth.LoginM.Errors.InvalidToken;
                             }
                             
                             var response = ApiResponse.CreateErrorResponse(message, errorCode: errorCode);
+
+                            await context.Response.WriteAsJsonAsync(response);
+                        },
+                        OnForbidden = async context =>
+                        {                            
+                            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                            context.Response.ContentType = "application/json";
+
+                            var response = ApiResponse.CreateErrorResponse(
+                                Auth.LoginM.Errors.AccessForbidden,
+                                errorCode: Auth.LoginM.Errors.AccessForbiddenErrorCode
+                            );
 
                             await context.Response.WriteAsJsonAsync(response);
                         }


### PR DESCRIPTION


- Implement OnForbidden event to handle 403 Access Denied cases with structured ApiResponse.
- Move all authentication-related error messages and codes to Auth.LoginM.Errors constants.
- Refactor OnChallenge logic to use the new centralized constant strings and error codes.