### PR TITLE
fix: persist IsActive value instead of hardcoded true

### DIFF
--- a/CookingBlogBackend/PostApiService/Helper/PostMappingExtensions.cs
+++ b/CookingBlogBackend/PostApiService/Helper/PostMappingExtensions.cs
@@ -108,7 +108,7 @@ namespace PostApiService.Helper
                     : dto.MetaDescription.StripHtml(),
 
                 CreatedAt = DateTime.UtcNow,
-                IsActive = true
+                IsActive = dto.IsActive
             };
         }
 

--- a/CookingBlogBackend/PostApiService/Models/Dto/Requests/PostCreateDto.cs
+++ b/CookingBlogBackend/PostApiService/Models/Dto/Requests/PostCreateDto.cs
@@ -32,6 +32,6 @@ namespace PostApiService.Models.Dto.Requests
 
         [Range(1, int.MaxValue, ErrorMessage = Global.Validation.InvalidCategory)]
         public int CategoryId { get; init; }
+        public bool IsActive { get; init; } = false;
     }
-
 }


### PR DESCRIPTION
- Add IsActive field to PostCreateDto
- Remove hardcoded `IsActive = true` in PostMappingExtensions
- Post active/inactive status is now correctly saved and returned based on user input instead of being forced to true