### PR TITLE
fix: add IsActive to PostUpdateDto and fix related tests

### DIFF
--- a/CookingBlogBackend/PostApiService.Tests/Helper/TestDataHelper.cs
+++ b/CookingBlogBackend/PostApiService.Tests/Helper/TestDataHelper.cs
@@ -65,6 +65,7 @@ namespace PostApiService.Tests.Helper
                 .RuleFor(p => p.MetaTitle, f => f.Lorem.Sentence(2))
                 .RuleFor(p => p.MetaDescription, f => f.Lorem.Sentence(3).ClampLength(50, 200))
                 .RuleFor(p => p.Slug, f => f.Lorem.Slug())
+                .RuleFor(p => p.IsActive, f => true)
                 .RuleFor(p => p.UpdatedAt, f => f.Date.Recent(7).ToUniversalTime())
                 .RuleFor(p => p.Comments, (f, post) =>
                 {
@@ -108,7 +109,8 @@ namespace PostApiService.Tests.Helper
                 MetaTitle = post.MetaTitle,
                 MetaDescription = post.MetaDescription,
                 Slug = post.Slug,
-                CategoryId = post.CategoryId
+                CategoryId = post.CategoryId,
+                IsActive = post.IsActive
             };
         }
 
@@ -427,7 +429,8 @@ namespace PostApiService.Tests.Helper
                 ImageUrl = "http://example.com/image.jpg",
                 MetaTitle = "Updated Meta Title",
                 MetaDescription = "Updated Meta Description",
-                CategoryId = categoryId
+                CategoryId = categoryId,
+                IsActive = true
             };
         }
 

--- a/CookingBlogBackend/PostApiService/Helper/PostMappingExtensions.cs
+++ b/CookingBlogBackend/PostApiService/Helper/PostMappingExtensions.cs
@@ -131,6 +131,7 @@ namespace PostApiService.Helper
                     ? dto.Description.StripHtml()[..197] + "..."
                     : dto.Description.StripHtml())
                 : dto.MetaDescription.StripHtml();
+            entity.IsActive = dto.IsActive!.Value;
         }
     }
 }

--- a/CookingBlogBackend/PostApiService/Models/Dto/Requests/PostUpdateDto.cs
+++ b/CookingBlogBackend/PostApiService/Models/Dto/Requests/PostUpdateDto.cs
@@ -32,5 +32,8 @@ namespace PostApiService.Models.Dto.Requests
 
         [Range(1, int.MaxValue, ErrorMessage = Global.Validation.InvalidCategory)]
         public int CategoryId { get; init; }
+
+        [Required(ErrorMessage = Global.Validation.Required)]
+        public bool? IsActive { get; init; }
     }
 }

--- a/postman/collection.json
+++ b/postman/collection.json
@@ -1,9 +1,10 @@
 {
   "info": {
-    "_postman_id": "4117c7ac-9b4f-4fe5-80c2-b9f234efdcc1",
+    "_postman_id": "e011de73-4e62-4642-9f0f-7c0027f542c7",
     "name": "CookingBlog Integration Tests",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "40053538"
+    "_exporter_id": "40053538",
+    "_collection_link": "https://go.postman.co/collection/40053538-e011de73-4e62-4642-9f0f-7c0027f542c7?source=collection_link"
   },
   "item": [
     {
@@ -422,7 +423,7 @@
                   "const uniqueTitle = \"Post title \" + timestamp;\r",
                   "const slug = uniqueTitle.toLowerCase().replace(/ /g, '-');\r",
                   "\r",
-                  "pm.variables.set(\"unique_post_title\", uniqueTitle);\r",
+                  "pm.variables.set(\"post_title\", uniqueTitle);\r",
                   "pm.variables.set(\"unique_post_slug\", slug);"
                 ],
                 "type": "text/javascript",
@@ -446,7 +447,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\r\n    \"title\": \"{{unique_post_title}}\",\r\n    \"description\": \"This is a sample description for the post.\",\r\n    \"content\": \"This is the detailed content of the post. It provides in-depth information about the topic.\",\r\n    \"author\": \"Peter\",\r\n    \"imageUrl\": \"https://example.com/sample-image.jpg\",\r\n    \"metaTitle\": \"Sample Meta Title\",\r\n    \"metaDescription\": \"This is a sample meta description for SEO purposes.\",\r\n    \"slug\": \"{{unique_post_slug}}\",\r\n    \"categoryId\": \"{{temp_category_id}}\"\r\n}",
+              "raw": "{\r\n    \"title\": \"{{post_title}}\",\r\n    \"description\": \"This is a sample description for the post.\",\r\n    \"content\": \"This is the detailed content of the post. It provides in-depth information about the topic.\",\r\n    \"author\": \"Peter\",\r\n    \"imageUrl\": \"https://example.com/sample-image.jpg\",\r\n    \"metaTitle\": \"Sample Meta Title\",\r\n    \"metaDescription\": \"This is a sample meta description for SEO purposes.\",\r\n    \"isActive\": true,\r\n    \"slug\": \"{{unique_post_slug}}\",\r\n    \"categoryId\": \"{{temp_category_id}}\"\r\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -793,7 +794,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\r\n    \"title\": \"{{updated_post_title}}\",\r\n    \"description\": \"This is a sample description for the post.\",\r\n    \"content\": \"This is the detailed content of the post. It provides in-depth information about the topic.\",\r\n    \"author\": \"John Doe\",\r\n    \"imageUrl\": \"https://example.com/changed-image.jpg\",\r\n    \"metaTitle\": \"Sample changed Meta Title\",\r\n    \"metaDescription\": \"This is a changed sample meta description for SEO purposes.\",\r\n    \"slug\": \"{{updated_post_slug}}\",\r\n    \"categoryId\": {{temp_category_id}}\r\n}",
+              "raw": "{\r\n    \"title\": \"{{updated_post_title}}\",\r\n    \"description\": \"This is a sample description for the post.\",\r\n    \"content\": \"This is the detailed content of the post. It provides in-depth information about the topic.\",\r\n    \"author\": \"John Doe\",\r\n    \"imageUrl\": \"https://example.com/changed-image.jpg\",\r\n    \"metaTitle\": \"Sample changed Meta Title\",\r\n    \"metaDescription\": \"This is a changed sample meta description for SEO purposes.\",\r\n    \"isActive\": true,\r\n    \"slug\": \"{{updated_post_slug}}\",\r\n    \"categoryId\": {{temp_category_id}}\r\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/postman/environment.json
+++ b/postman/environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "516428b7-19ae-4284-90ca-655db4ace20f",
+	"id": "25853633-e6f1-42d9-95d9-c8e22ca8d3f4",
 	"name": "CookingBlogBackend",
 	"values": [
 		{
@@ -51,12 +51,6 @@
 			"enabled": true
 		},
 		{
-			"key": "temp_category_slug",
-			"value": "",
-			"type": "any",
-			"enabled": true
-		},
-		{
 			"key": "temp_category_name",
 			"value": "",
 			"type": "any",
@@ -67,10 +61,28 @@
 			"value": "",
 			"type": "any",
 			"enabled": true
+		},
+		{
+			"key": "debug_post_slug",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "debug_category_slug",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "post_slug",
+			"value": "",
+			"type": "any",
+			"enabled": true
 		}
 	],
 	"color": null,
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2026-01-31T15:42:04.344Z",
-	"_postman_exported_using": "Postman/11.82.6"
+	"_postman_exported_at": "2026-07-03T12:46:41.743Z",
+	"_postman_exported_using": "Postman/12.4.2"
 }


### PR DESCRIPTION
- Make IsActive nullable and required in PostUpdateDto to fail fast on missing value instead of silently defaulting to false
- Update UpdateEntity mapping to unwrap nullable IsActive
- Fix TestDataHelper to provide default IsActive value for PostUpdateDto and Post faker
- Add isActive field to AddNewPost and UpdatePost request bodies
  in Postman collection